### PR TITLE
Rewrite command line arguments

### DIFF
--- a/ConsoleApp/ConsoleApp.csproj
+++ b/ConsoleApp/ConsoleApp.csproj
@@ -12,7 +12,7 @@
     <ErrorReport>none</ErrorReport>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
     <StartupObject>ConsoleApp.Program</StartupObject>
-    <Version>0.0.8.0</Version>
+    <Version>0.0.9.0</Version>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>

--- a/ConsoleApp/ConsoleApp.csproj
+++ b/ConsoleApp/ConsoleApp.csproj
@@ -32,6 +32,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\WindowsInstallerLib\WindowsInstallerLib.csproj" />
   </ItemGroup>
 

--- a/ConsoleApp/src/ArgumentParser.cs
+++ b/ConsoleApp/src/ArgumentParser.cs
@@ -1,90 +1,22 @@
 ﻿using System;
-using System.Globalization;
 using System.Runtime.Versioning;
 using WindowsInstallerLib;
 
 namespace ConsoleApp
 {
-    /// <summary>
-    /// Manages everything related to the command line arguments.
-    /// </summary>
     [SupportedOSPlatform("windows")]
     internal sealed class ArgumentParser
     {
-        /// <summary>
-        /// Validates and parses the command line arguments.
-        /// </summary>
-        /// <param name="args"></param>
-        internal static void ParseArgs(ref Parameters parameters, string[] args)
+        internal static void ParseArgs(Parameters parameters, string[] args)
         {
-            if (args.Length == 0)
+            try
             {
-                return;
+                ProgramOptions.ParseArgs(parameters, args);
             }
-
-            foreach (string arg in args)
+            catch
             {
-                switch (arg.ToLower(CultureInfo.CurrentCulture))
-                {
-                    case "/?" or "/h":
-                        Console.WriteLine($"\nUsage: {ProgramInfo.GetName()} [options]");
-                        Console.WriteLine("\nOptions:");
-                        Console.WriteLine("  /DestinationDrive <drive>  Specifies the mountpoint to use for deploying Windows.");
-                        Console.WriteLine("  /EfiDrive <drive>          Specifies the mountpoint to use for the EFI partition.");
-                        Console.WriteLine("  /DiskNumber <number>       Specifies the disk number to use for deploying Windows.");
-                        Console.WriteLine("  /SourceDrive <drive>       Specifies the mountpoint to use for the Windows image.");
-                        Console.WriteLine("  /ImageIndex <number>       Specifies the index of the Windows image to deploy.");
-                        Console.WriteLine("  /ImageFilePath <path>      Specifies the path to the Windows image to deploy.");
-                        Console.WriteLine("  /InstallExtraDrivers       Installs additional drivers during the deployment.");
-                        Console.WriteLine("  /FirmwareType <type>       Specifies the firmware type to use for the deployment.");
-                        Console.WriteLine("  /?, /h                     Displays this help message.\n");
-                        Environment.Exit(0);
-                        return;
-                    case "/destinationdrive":
-                        parameters.DestinationDrive = args[Array.IndexOf(args, arg) + 1].ToUpperInvariant();
-                        continue;
-                    case "/efidrive":
-                        parameters.EfiDrive = args[Array.IndexOf(args, arg) + 1].ToUpperInvariant();
-                        continue;
-                    case "/disknumber":
-                        parameters.DiskNumber = Convert.ToInt32(args[Array.IndexOf(args, arg) + 1], CultureInfo.CurrentCulture);
-                        continue;
-                    case "/sourcedrive":
-                        parameters.SourceDrive = args[Array.IndexOf(args, arg) + 1].ToUpperInvariant();
-                        continue;
-                    case "/imageindex":
-                        parameters.ImageIndex = Convert.ToInt32(args[Array.IndexOf(args, arg) + 1], CultureInfo.CurrentCulture);
-                        continue;
-                    case "/imagefilepath":
-                        parameters.ImageFilePath = args[Array.IndexOf(args, arg) + 1].ToLowerInvariant();
-                        continue;
-                    case "/additionaldriversdrive":
-                        parameters.AdditionalDrive = args[Array.IndexOf(args, arg) + 1].ToLowerInvariant();
-                        continue;
-                    case "/firmwaretype":
-                        parameters.FirmwareType = args[Array.IndexOf(args, arg) + 1].ToUpperInvariant();
-                        continue;
-                    default:
-                        if (arg.StartsWith("/", StringComparison.CurrentCulture) || !string.IsNullOrWhiteSpace(arg))
-                        {
-                            throw new ArgumentException($"Unknown argument: {arg}");
-                        }
-                        break;
-                }
+                throw;
             }
-#if DEBUG
-            Console.WriteLine("Parameters:");
-            Console.WriteLine($"  Destination Drive: {parameters.DestinationDrive}");
-            Console.WriteLine($"  EFI Drive: {parameters.EfiDrive}");
-            Console.WriteLine($"  Disk Number: {parameters.DiskNumber}");
-            Console.WriteLine($"  Source Drive: {parameters.SourceDrive}");
-            Console.WriteLine($"  Image Index: {parameters.ImageIndex}");
-            Console.WriteLine($"  Image File Path: {parameters.ImageFilePath}");
-            Console.WriteLine($"  Additional Drivers Drive: {parameters.AdditionalDrive}");
-            Console.WriteLine($"  Firmware Type: {parameters.FirmwareType}");
-            Console.WriteLine("Press any key to continue...");
-            Console.ReadKey();
-#endif
         }
     }
 }

--- a/ConsoleApp/src/Program.cs
+++ b/ConsoleApp/src/Program.cs
@@ -37,7 +37,7 @@ namespace ConsoleApp
 
             try
             {
-                ArgumentParser.ParseArgs(ref parameters, args);
+                ArgumentParser.ParseArgs(parameters, args);
             }
             catch (Exception ex)
             {

--- a/ConsoleApp/src/ProgramOptions.cs
+++ b/ConsoleApp/src/ProgramOptions.cs
@@ -1,0 +1,154 @@
+﻿using CommandLine;
+using System;
+using WindowsInstallerLib;
+
+namespace ConsoleApp
+{
+    [Verb("install", HelpText = "Deploy Windows to a target disk")]
+    internal sealed class ProgramOptions
+    {
+        [Option(
+            'd',
+            "destination-drive",
+            Required = false,
+            HelpText = "Specifies the mountpoint to use for deploying Windows.")]
+        public string? DestinationDrive { get; set; }
+
+        [Option(
+            'e',
+            "efi-drive",
+            Required = false,
+            HelpText = "Specifies the mountpoint to use for the EFI partition.")]
+        public string? EfiDrive { get; set; }
+
+        [Option(
+            'n',
+            "disk-number",
+            Required = false,
+            HelpText = "Specifies the disk number to use for deploying Windows.")]
+        public int? DiskNumber { get; set; }
+
+        [Option(
+            's',
+            "source-drive",
+            Required = false,
+            HelpText = "Specifies the mountpoint to use for the Windows image.")]
+        public string? SourceDrive { get; set; }
+
+        [Option(
+            'i',
+            "image-index",
+            Required = false,
+            HelpText = "Specifies the index of the Windows image to deploy.")]
+        public int? ImageIndex { get; set; }
+
+        [Option(
+            'p',
+            "image-file-path",
+            Required = false,
+            HelpText = "Specifies the path to the Windows image to deploy.")]
+        public string? ImageFilePath { get; set; }
+
+        [Option(
+            'a',
+            "additional-drivers-drive",
+            Required = false,
+            HelpText = "Specifies the mountpoint to use for additional drivers.")]
+        public string? AdditionalDrive { get; set; }
+
+        [Option(
+            'f',
+            "firmware-type",
+            Required = false,
+            HelpText = "Specifies the firmware type to use for the deployment (UEFI or BIOS).")]
+
+        public string? FirmwareType { get; set; }
+
+        internal static void PrintHelp()
+        {
+            Console.WriteLine($"\nUsage: {ProgramInfo.GetName()} [options]");
+            Console.WriteLine("\nOptions:");
+            Console.WriteLine("  -d, --destination-drive <drive>       Specifies the mountpoint to use for deploying Windows.");
+            Console.WriteLine("  -e, --efi-drive <drive>               Specifies the mountpoint to use for the EFI partition.");
+            Console.WriteLine("  -n, --disk-number <number>            Specifies the disk number to use for deploying Windows.");
+            Console.WriteLine("  -s, --source-drive <drive>            Specifies the mountpoint to use for the Windows image.");
+            Console.WriteLine("  -i, --image-index <number>            Specifies the index of the Windows image to deploy.");
+            Console.WriteLine("  -p, --image-file-path <path>          Specifies the path to the Windows image to deploy.");
+            Console.WriteLine("  -a, --additional-drivers-drive <path> Specifies the mountpoint to use for additional drivers.");
+            Console.WriteLine("  -f, --firmware-type <type>            Specifies the firmware type to use for the deployment.");
+            Console.WriteLine("  -h, --help                            Displays this help message.\n");
+        }
+
+        internal static void ApplyOptions(Parameters parameters, ProgramOptions options)
+        {
+            if (!string.IsNullOrEmpty(options.DestinationDrive))
+                parameters.DestinationDrive = options.DestinationDrive.ToUpperInvariant();
+
+            if (!string.IsNullOrEmpty(options.EfiDrive))
+                parameters.EfiDrive = options.EfiDrive.ToUpperInvariant();
+
+            if (options.DiskNumber.HasValue)
+                parameters.DiskNumber = options.DiskNumber.Value;
+
+            if (!string.IsNullOrEmpty(options.SourceDrive))
+                parameters.SourceDrive = options.SourceDrive.ToUpperInvariant();
+
+            if (options.ImageIndex.HasValue)
+                parameters.ImageIndex = options.ImageIndex.Value;
+
+            if (!string.IsNullOrEmpty(options.ImageFilePath))
+                parameters.ImageFilePath = options.ImageFilePath.ToLowerInvariant();
+
+            if (!string.IsNullOrEmpty(options.AdditionalDrive))
+                parameters.AdditionalDrive = options.AdditionalDrive.ToLowerInvariant();
+
+            if (!string.IsNullOrEmpty(options.FirmwareType))
+                parameters.FirmwareType = options.FirmwareType.ToUpperInvariant();
+        }
+
+        internal static void ParseArgs(Parameters parameters, string[] args)
+        {
+            if (args.Length == 0)
+            {
+                PrintHelp();
+                return;
+            }
+
+            ParserResult<ProgramOptions>? result = Parser.Default.ParseArguments<ProgramOptions>(args);
+
+            try
+            {
+                result
+                    .WithParsed(options => ApplyOptions(parameters, options))
+                    .WithNotParsed(errors =>
+                    {
+                        foreach (Error? error in errors)
+                        {
+                            throw error.Tag switch
+                            {
+                                _ => new ArgumentException($"{error}")
+                            };
+                        }
+                    });
+            }
+            catch (ArgumentException)
+            {
+                throw;
+            }
+
+#if DEBUG
+            Console.WriteLine("Parameters:");
+            Console.WriteLine($"  Destination Drive: {parameters.DestinationDrive}");
+            Console.WriteLine($"  EFI Drive: {parameters.EfiDrive}");
+            Console.WriteLine($"  Disk Number: {parameters.DiskNumber}");
+            Console.WriteLine($"  Source Drive: {parameters.SourceDrive}");
+            Console.WriteLine($"  Image Index: {parameters.ImageIndex}");
+            Console.WriteLine($"  Image File Path: {parameters.ImageFilePath}");
+            Console.WriteLine($"  Additional Drivers Drive: {parameters.AdditionalDrive}");
+            Console.WriteLine($"  Firmware Type: {parameters.FirmwareType}");
+            Console.WriteLine("Press any key to continue...");
+            Console.ReadKey();
+#endif
+        }
+    }
+}

--- a/scripts/compile-installer-cleanup.bat
+++ b/scripts/compile-installer-cleanup.bat
@@ -9,7 +9,7 @@ SET REPOSITORYDIR="%~dp0.."
 SET OUTPUTDIR="%~dp0..\build-installer"
 SET SETUPSCRIPT="%~dp0..\build-installer\wcit-setup.iss"
 SET USERNAME="felgmar"
-SET VERSION="1.0.1.1"
+SET VERSION="1.0.2.0"
 
 IF NOT EXIST %LICENSE% (
     ECHO.ERROR: LICENSE FILE NOT FOUND


### PR DESCRIPTION
Instead of manually validating the arguments, make use of System.CommandLine to do the job. Cleaner, safer and probably easier to maintain.